### PR TITLE
Fix incorrect "/favicon.ico" string match

### DIFF
--- a/src/server/httpd.cpp
+++ b/src/server/httpd.cpp
@@ -284,7 +284,7 @@ int answer_to_connection(void *cls, struct MHD_Connection *connection, const cha
 			contentType = strdup("text/plain");
 			os << "User-agent: *\nDisallow: /\n";
 
-		} else if(!std::strncmp("/favicon.ico", url, 8)) {
+		} else if(!std::strncmp("/favicon.ico", url, 12)) {
 
 			cp = NetMauMau::Server::CachePolicyFactory::getInstance()->createPublicCachePolicy();
 


### PR DESCRIPTION
This fixes an incorrect size argument passed to `strncmp` as the string has a length of 12.